### PR TITLE
ITSE-756 use the amazon linux 2 runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 .idea/
+
+# Go output binary
+bootstrap
 aws.env
 *.aes
 vendor/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19
+FROM golang:1.21
 
 # Install packages
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,9 @@
 FROM golang:1.21
 
-# Install packages
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
-RUN apt-get install -y nodejs
+RUN curl -o- -L https://slss.io/install | VERSION=3.37.0 bash && \
+  mv $HOME/.serverless/bin/serverless /usr/local/bin && \
+  ln -s /usr/local/bin/serverless /usr/local/bin/sls
 
 WORKDIR /src
-
-RUN npm --no-fund install -g serverless@3
-
 COPY ./ .
 RUN go get ./...

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018-2022 SIL International
+Copyright (c) 2018-2023 SIL International
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -4,8 +4,3 @@ app:
   encrypted_env_file: aws.env.encrypted
   cached: true
   working_dir: /src
-
-tracker:
-  image: silintl/app-deployment-tracker-ga:latest
-  environment:
-    TRACKING_ID: UA-56269387-10

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -2,8 +2,3 @@
   service: app
   tag: ^(main|develop)
   command: ./deploy-lambdas.sh
-
-- name: track_deployment
-  service: tracker
-  tag: main
-  command: "true"

--- a/deploy-lambdas.sh
+++ b/deploy-lambdas.sh
@@ -6,7 +6,7 @@ set -e
 # Echo each command in the script
 set -x
 
-# build binary
+# When using the provided.al2 runtime, the binary must be named "bootstrap" and be in the root directory
 CGO_ENABLED=0 go build -tags lambda.norpc -ldflags="-s -w" -o bootstrap
 
 STAGE="dev"

--- a/deploy-lambdas.sh
+++ b/deploy-lambdas.sh
@@ -7,7 +7,7 @@ set -e
 set -x
 
 # build binary
-go build -ldflags="-s -w" -o ecs-right-size-cluster
+CGO_ENABLED=0 go build -tags lambda.norpc -ldflags="-s -w" -o bootstrap
 
 STAGE="dev"
 export ClusterNamesCSV="${ClusterNamesCSV_dev}"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/silinternational/ecs-right-size-cluster-lambda
 
-go 1.19
+go 1.21
 
 require (
 	github.com/aws/aws-lambda-go v1.38.0

--- a/serverless.yml
+++ b/serverless.yml
@@ -7,7 +7,7 @@ frameworkVersion: ^3.2.0
 
 provider:
   name: aws
-  runtime: go1.x
+  runtime: provided.al2
   timeout: 30
   versionFunctions: false
   memorySize: 128
@@ -45,12 +45,12 @@ custom:
 
 package:
   patterns:
-  - ./**
-  - ./ecs-right-size-cluster
+    - '!./**'
+    - './bootstrap'
 
 functions:
   ecsRightSizeCluster:
-    handler: ecs-right-size-cluster
+    handler: bootstrap
     events:
     - schedule:
         rate: rate(10 minutes) # every 10 minutes

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,7 +4,7 @@
  */
 module "serverless-user" {
   source  = "silinternational/serverless-user/aws"
-  version = "0.1.3"
+  version = "0.3.2"
 
   app_name   = "ecs-right-size"
   aws_region = var.aws_region


### PR DESCRIPTION
### Changed
- Use the Amazon Linux 2 Lambda runtime due to the deprecation of the go1.x runtime

### Removed
- Remove the deployment tracker.

### Fixed
- Use Go 1.21
- Download the serverless binary using curl, not npm.
- Use the latest version of the serverless-user Terraform module.

[ITSE-756](https://itse.youtrack.cloud/issue/ITSE-756)